### PR TITLE
Fix auth mode and improve data keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,19 @@ export default tseslint.config([
   },
 ])
 ```
+
+## Quick start
+
+Install dependencies and run the development server:
+
+```bash
+npm install
+npm run dev
+```
+
+To lint and build the project (requires dependencies installed):
+
+```bash
+npm run lint
+npm run build
+```

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ function App() {
   // добавлена страница 'child'
   const [page, setPage] = useState<'home' | 'catalog' | 'auth' | 'parent' | 'club' | 'admin' | 'child'>('home');
   const [user, setUser] = useState<{ role: string, name: string } | null>(null);
+  const [authMode, setAuthMode] = useState<'login' | 'register'>('register');
 
   return (
     <div style={{
@@ -178,7 +179,10 @@ function App() {
                   cursor: 'pointer',
                   boxShadow: '0 2px 8px #0001'
                 }}
-                onClick={() => setPage('auth')}
+                onClick={() => {
+                  setAuthMode('login');
+                  setPage('auth');
+                }}
               >
                 Login
               </button>
@@ -194,7 +198,10 @@ function App() {
                   cursor: 'pointer',
                   boxShadow: '0 2px 8px #4aa7f526'
                 }}
-                onClick={() => setPage('auth')}
+                onClick={() => {
+                  setAuthMode('register');
+                  setPage('auth');
+                }}
               >
                 Регистрация
               </button>
@@ -252,6 +259,7 @@ function App() {
         {page === 'catalog' && <ClubsCatalog />}
         {page === 'auth' && (
           <AuthPage
+            defaultMode={authMode}
             onLogin={(role, name) => {
               setUser({ role, name });
               setPage('home');

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -3,12 +3,13 @@ import { RoleSelector } from '../components/RoleSelector';
 
 type Props = {
   onLogin: (role: string, name: string) => void;
+  defaultMode?: 'login' | 'register';
 };
 
-export default function AuthPage({ onLogin }: Props) {
+export default function AuthPage({ onLogin, defaultMode = 'register' }: Props) {
   const [role, setRole] = useState('parent');
   const [name, setName] = useState('');
-  const [mode, setMode] = useState<'login' | 'register'>('register');
+  const [mode, setMode] = useState<'login' | 'register'>(defaultMode);
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();

--- a/src/pages/ChildProfile.tsx
+++ b/src/pages/ChildProfile.tsx
@@ -4,12 +4,12 @@ const mockProfile = {
   photoUrl: 'https://randomuser.me/api/portraits/med/women/43.jpg',
   interests: ['Робототехника', 'Рисование', 'Футбол'],
   achievements: [
-    { title: '1 место на олимпиаде по робототехнике', year: 2024 },
-    { title: 'Грамота за активное участие', year: 2023 },
+    { id: 1, title: '1 место на олимпиаде по робототехнике', year: 2024 },
+    { id: 2, title: 'Грамота за активное участие', year: 2023 },
   ],
   documents: [
-    { title: 'Медицинская справка', file: 'med-spravka.pdf' },
-    { title: 'Договор', file: 'dogovor.pdf' },
+    { id: 1, title: 'Медицинская справка', file: 'med-spravka.pdf' },
+    { id: 2, title: 'Договор', file: 'dogovor.pdf' },
   ],
 };
 
@@ -75,8 +75,8 @@ export default function ChildProfile() {
           gap: 20,
           flexWrap: 'wrap'
         }}>
-          {mockProfile.achievements.map((ach, idx) => (
-            <div key={idx} style={{
+          {mockProfile.achievements.map(ach => (
+            <div key={ach.id} style={{
               background: '#fff',
               borderRadius: 14,
               boxShadow: '0 2px 8px #4AA7F515',
@@ -109,8 +109,8 @@ export default function ChildProfile() {
           fontWeight: 700,
           fontSize: 16
         }}>
-          {mockProfile.documents.map((doc, idx) => (
-            <li key={idx} style={{ marginBottom: 8 }}>
+          {mockProfile.documents.map(doc => (
+            <li key={doc.id} style={{ marginBottom: 8 }}>
               <a
                 href={`#${doc.file}`}
                 style={{

--- a/src/pages/ClubDashboard.tsx
+++ b/src/pages/ClubDashboard.tsx
@@ -11,8 +11,8 @@ const mockClub = {
 };
 
 const mockSchedule = [
-  { name: 'Робототехника', days: 'Пн, Ср, Пт', time: '15:00–16:30' },
-  { name: 'Шахматы', days: 'Вт, Чт', time: '16:00–17:00' }
+  { id: 1, name: 'Робототехника', days: 'Пн, Ср, Пт', time: '15:00–16:30' },
+  { id: 2, name: 'Шахматы', days: 'Вт, Чт', time: '16:00–17:00' }
 ];
 
 export default function ClubDashboard() {
@@ -97,8 +97,8 @@ export default function ClubDashboard() {
           marginBottom: 14
         }}>👩‍🏫 Педагоги</div>
         <ul style={{ paddingLeft: 18, fontSize: 16, fontWeight: 700, color: '#34480A' }}>
-          {mockClub.teachers.map((t, idx) => (
-            <li key={idx} style={{ marginBottom: 6 }}>{t}</li>
+          {mockClub.teachers.map(t => (
+            <li key={t} style={{ marginBottom: 6 }}>{t}</li>
           ))}
         </ul>
       </div>
@@ -132,8 +132,8 @@ export default function ClubDashboard() {
             </tr>
           </thead>
           <tbody>
-            {mockSchedule.map((row, idx) => (
-              <tr key={idx} style={{ background: idx % 2 === 0 ? '#F7FCFF' : '#fff' }}>
+            {mockSchedule.map(row => (
+              <tr key={row.id} style={{ background: row.id % 2 === 0 ? '#F7FCFF' : '#fff' }}>
                 <td style={{ padding: 9 }}>{row.name}</td>
                 <td style={{ padding: 9 }}>{row.days}</td>
                 <td style={{ padding: 9 }}>{row.time}</td>

--- a/src/pages/ClubsCatalog.tsx
+++ b/src/pages/ClubsCatalog.tsx
@@ -1,5 +1,6 @@
 const mockClubs = [
   {
+    id: 1,
     name: 'Робототехника Junior',
     city: 'Астана',
     address: 'ул. Абая, 11',
@@ -10,6 +11,7 @@ const mockClubs = [
     desc: 'Роботы, 3D-принтеры, соревнования и творчество для детей.',
   },
   {
+    id: 2,
     name: 'Шахматная академия',
     city: 'Астана',
     address: 'пр. Мангилик Ел, 12',
@@ -20,6 +22,7 @@ const mockClubs = [
     desc: 'Обучение шахматам в группах и индивидуально. Турниры каждую неделю!',
   },
   {
+    id: 3,
     name: 'Арт-студия "Краски"',
     city: 'Астана',
     address: 'ул. Сарыарка, 7',
@@ -68,8 +71,8 @@ export default function ClubsCatalog() {
         gap: 32,
         gridTemplateColumns: 'repeat(auto-fit,minmax(320px,1fr))'
       }}>
-        {mockClubs.map((club, idx) => (
-          <div key={idx} style={{
+        {mockClubs.map(club => (
+          <div key={club.id} style={{
             background: '#fff',
             borderRadius: 26,
             boxShadow: '0 4px 24px #0001',

--- a/src/pages/ParentDashboard.tsx
+++ b/src/pages/ParentDashboard.tsx
@@ -6,13 +6,13 @@ const mockChild = {
 };
 
 const mockRecords = [
-  { club: 'Робототехника Junior', date: '2024-09-01', status: 'Записан' },
-  { club: 'Футбольная секция "Звезда"', date: '2024-09-02', status: 'Посещено' }
+  { id: 1, club: 'Робототехника Junior', date: '2024-09-01', status: 'Записан' },
+  { id: 2, club: 'Футбольная секция "Звезда"', date: '2024-09-02', status: 'Посещено' }
 ];
 
 const mockEvents = [
-  { date: '2024-09-03', event: 'Открытый урок по рисованию' },
-  { date: '2024-09-05', event: 'Запись в "Робототехника Junior"' }
+  { id: 1, date: '2024-09-03', event: 'Открытый урок по рисованию' },
+  { id: 2, date: '2024-09-05', event: 'Запись в "Робототехника Junior"' }
 ];
 
 export default function ParentDashboard() {
@@ -85,8 +85,8 @@ export default function ParentDashboard() {
             letterSpacing: 1
           }}>История записей</div>
           <ul style={{ paddingLeft: 14, fontSize: 15, fontWeight: 600, color: '#34480A' }}>
-            {mockRecords.map((rec, idx) => (
-              <li key={idx} style={{ marginBottom: 7 }}>
+            {mockRecords.map(rec => (
+              <li key={rec.id} style={{ marginBottom: 7 }}>
                 <span style={{ color: '#4AA7F5', fontWeight: 800 }}>{rec.club}</span><br />
                 <span style={{ color: '#888' }}>{rec.date}</span>{' '}
                 <b style={{
@@ -114,8 +114,8 @@ export default function ParentDashboard() {
             letterSpacing: 1
           }}>Ближайшие события</div>
           <ul style={{ paddingLeft: 14, fontSize: 15, fontWeight: 600, color: '#B88D0B' }}>
-            {mockEvents.map((ev, idx) => (
-              <li key={idx} style={{ marginBottom: 7 }}>
+            {mockEvents.map(ev => (
+              <li key={ev.id} style={{ marginBottom: 7 }}>
                 <span style={{ color: '#4AA7F5', fontWeight: 800 }}>{ev.date}</span>{' '}
                 <span>{ev.event}</span>
               </li>


### PR DESCRIPTION
## Summary
- allow `AuthPage` to specify login or register mode
- support auth mode selection in `App`
- document installation steps
- avoid index keys in pages

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6860361e95f48329af40fdea2bfd5548