### PR TITLE
Enable GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,24 @@
+name: Deploy to GitHub Pages
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+      - uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -83,3 +83,22 @@ To lint and build the project (requires dependencies installed):
 npm run lint
 npm run build
 ```
+
+## Deploy
+
+This project can be published on **GitHub Pages**. The `base` option in
+`vite.config.ts` is set to `/aliedu-web/` so that the app works when served from
+the repository subpath.
+
+Automatic deployment is handled by a GitHub Actions workflow:
+
+1. Enable GitHub Pages in the repository settings.
+2. Push to the `main` branch. The workflow builds the project and publishes the
+   contents of `dist/` to the `gh-pages` branch.
+
+If you prefer to deploy manually, build the project locally and upload the
+`dist/` directory.
+
+```bash
+npm run build
+```

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,5 +3,6 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: '/aliedu-web/',
   plugins: [react()],
 })


### PR DESCRIPTION
## Summary
- add GitHub Pages workflow
- configure Vite base path
- document deployment steps in README
- fix Pages deployment permission

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing 'react' type declarations)*


------
https://chatgpt.com/codex/tasks/task_e_686039620d1c8329b030f18f1bcaf090