### PR TITLE
Add basic API and replace mock data with fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "server": "node server.js"
   },
   "dependencies": {
     "react": "^19.1.0",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,130 @@
+import http from 'node:http';
+import { parse } from 'node:url';
+
+const clubs = [
+  {
+    id: 1,
+    name: 'Робототехника Junior',
+    city: 'Астана',
+    address: 'ул. Абая, 11',
+    direction: 'Техническое',
+    age: '7-11',
+    price: '20 000 ₸',
+    image: 'https://images.unsplash.com/photo-1519125323398-675f0ddb6308?auto=format&fit=facearea&w=400&q=80',
+    desc: 'Роботы, 3D-принтеры, соревнования и творчество для детей.'
+  },
+  {
+    id: 2,
+    name: 'Шахматная академия',
+    city: 'Астана',
+    address: 'пр. Мангилик Ел, 12',
+    direction: 'Логика',
+    age: '6-14',
+    price: '15 000 ₸',
+    image: 'https://images.unsplash.com/photo-1503676382389-4809596d5290?auto=format&fit=facearea&w=400&q=80',
+    desc: 'Обучение шахматам в группах и индивидуально. Турниры каждую неделю!'
+  },
+  {
+    id: 3,
+    name: 'Арт-студия "Краски"',
+    city: 'Астана',
+    address: 'ул. Сарыарка, 7',
+    direction: 'Творчество',
+    age: '5-12',
+    price: '18 000 ₸',
+    image: 'https://images.unsplash.com/photo-1517841905240-472988babdf9?w=400&q=80',
+    desc: 'Живопись, лепка, творчество и развитие эстетического вкуса.'
+  }
+];
+
+const parentDashboard = {
+  child: { name: 'Айжан', age: 9, interests: ['Робототехника', 'Рисование', 'Футбол'], photoUrl: 'https://randomuser.me/api/portraits/med/women/43.jpg' },
+  records: [
+    { id: 1, club: 'Робототехника Junior', date: '2024-09-01', status: 'Записан' },
+    { id: 2, club: 'Футбольная секция "Звезда"', date: '2024-09-02', status: 'Посещено' }
+  ],
+  events: [
+    { id: 1, date: '2024-09-03', event: 'Открытый урок по рисованию' },
+    { id: 2, date: '2024-09-05', event: 'Запись в "Робототехника Junior"' }
+  ]
+};
+
+const clubDashboard = {
+  club: {
+    name: 'Центр развития "Юный гений"',
+    city: 'Астана',
+    phone: '+7 777 123 4567',
+    email: 'info@jun-gen.kz',
+    address: 'ул. Абая, 10',
+    directions: ['Робототехника', 'Шахматы', 'Арт-студия'],
+    studentsCount: 32,
+    teachers: ['Иванов А.А.', 'Серикова М.М.'],
+    photoUrl: 'https://images.unsplash.com/photo-1517841905240-472988babdf9?w=400&q=80'
+  },
+  schedule: [
+    { id: 1, name: 'Робототехника', days: 'Пн, Ср, Пт', time: '15:00–16:30' },
+    { id: 2, name: 'Шахматы', days: 'Вт, Чт', time: '16:00–17:00' }
+  ]
+};
+
+const adminDashboard = {
+  stats: { clubs: 12, parents: 41, students: 56, pendingClubs: 2, reviews: 7 },
+  complaints: [
+    { id: 1, text: 'Некорректная информация о кружке "Футбольная секция"', status: 'Новая' },
+    { id: 2, text: 'Жалоба на поведение педагога', status: 'В работе' }
+  ],
+  users: [
+    { id: 1, name: 'Айжан', role: 'parent' },
+    { id: 2, name: 'Юный гений', role: 'club' },
+    { id: 3, name: 'Админ', role: 'admin' }
+  ]
+};
+
+const server = http.createServer((req, res) => {
+  const url = parse(req.url, true);
+  if (req.method === 'GET' && url.pathname === '/api/clubs') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(clubs));
+    return;
+  }
+  if (req.method === 'GET' && url.pathname === '/api/parent/dashboard') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(parentDashboard));
+    return;
+  }
+  if (req.method === 'GET' && url.pathname === '/api/club/dashboard') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(clubDashboard));
+    return;
+  }
+  if (req.method === 'GET' && url.pathname === '/api/admin/dashboard') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(adminDashboard));
+    return;
+  }
+  if (req.method === 'POST' && url.pathname === '/api/login') {
+    let body = '';
+    req.on('data', chunk => {
+      body += chunk;
+    });
+    req.on('end', () => {
+      try {
+        const { role, name } = JSON.parse(body);
+        const token = Buffer.from(`${role}:${name}`).toString('base64');
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ token, role, name }));
+      } catch {
+        res.writeHead(400);
+        res.end();
+      }
+    });
+    return;
+  }
+  res.writeHead(404);
+  res.end();
+});
+
+const PORT = process.env.PORT || 3001;
+server.listen(PORT, () => {
+  console.log(`API server running on ${PORT}`);
+});

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -1,23 +1,20 @@
-const mockStats = {
-  clubs: 12,
-  parents: 41,
-  students: 56,
-  pendingClubs: 2,
-  reviews: 7,
+import { useEffect, useState } from 'react';
+
+type Dashboard = {
+  stats: { clubs: number; parents: number; students: number; pendingClubs: number; reviews: number };
+  complaints: { id: number; text: string; status: string }[];
+  users: { id: number; name: string; role: string }[];
 };
 
-const mockComplaints = [
-  { id: 1, text: 'Некорректная информация о кружке "Футбольная секция"', status: 'Новая' },
-  { id: 2, text: 'Жалоба на поведение педагога', status: 'В работе' },
-];
-
-const mockUsers = [
-  { id: 1, name: 'Айжан', role: 'parent' },
-  { id: 2, name: 'Юный гений', role: 'club' },
-  { id: 3, name: 'Админ', role: 'admin' },
-];
-
 export default function AdminDashboard() {
+  const [data, setData] = useState<Dashboard | null>(null);
+
+  useEffect(() => {
+    fetch('/api/admin/dashboard')
+      .then(r => r.json())
+      .then(setData)
+      .catch(() => setData(null));
+  }, []);
   return (
     <div style={{
       maxWidth: 960,
@@ -34,11 +31,11 @@ export default function AdminDashboard() {
         marginBottom: 34,
         flexWrap: 'wrap'
       }}>
-        <div style={statBox('#4AA7F5', '#fff')}>Кружков<br /><b>{mockStats.clubs}</b></div>
-        <div style={statBox('#A7E04B', '#233F11')}>Родителей<br /><b>{mockStats.parents}</b></div>
-        <div style={statBox('#F9D469', '#B88D0B')}>Ученики<br /><b>{mockStats.students}</b></div>
-        <div style={statBox('#FFF6A0', '#E3A00C')}>На модерации<br /><b>{mockStats.pendingClubs}</b></div>
-        <div style={statBox('#E4ECFF', '#4AA7F5')}>Отзывы<br /><b>{mockStats.reviews}</b></div>
+        <div style={statBox('#4AA7F5', '#fff')}>Кружков<br /><b>{data?.stats.clubs}</b></div>
+        <div style={statBox('#A7E04B', '#233F11')}>Родителей<br /><b>{data?.stats.parents}</b></div>
+        <div style={statBox('#F9D469', '#B88D0B')}>Ученики<br /><b>{data?.stats.students}</b></div>
+        <div style={statBox('#FFF6A0', '#E3A00C')}>На модерации<br /><b>{data?.stats.pendingClubs}</b></div>
+        <div style={statBox('#E4ECFF', '#4AA7F5')}>Отзывы<br /><b>{data?.stats.reviews}</b></div>
       </div>
 
       <div style={{
@@ -56,7 +53,7 @@ export default function AdminDashboard() {
           letterSpacing: 1
         }}>🚩 Жалобы и обращения</div>
         <ul style={{ paddingLeft: 16, fontSize: 15, fontWeight: 600 }}>
-          {mockComplaints.map(c => (
+          {data?.complaints.map(c => (
             <li key={c.id} style={{
               marginBottom: 9,
               color: c.status === 'Новая' ? '#E76431' : '#34480A'
@@ -97,7 +94,7 @@ export default function AdminDashboard() {
             </tr>
           </thead>
           <tbody>
-            {mockUsers.map(u => (
+            {data?.users.map(u => (
               <tr key={u.id} style={{ background: u.role === 'admin' ? '#E4ECFF' : '#fff' }}>
                 <td style={{ padding: 9 }}>{u.name}</td>
                 <td style={{

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -11,10 +11,22 @@ export default function AuthPage({ onLogin, defaultMode = 'register' }: Props) {
   const [name, setName] = useState('');
   const [mode, setMode] = useState<'login' | 'register'>(defaultMode);
 
-  function handleSubmit(e: React.FormEvent) {
+  async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (name.trim().length < 2) return;
-    onLogin(role, name);
+    try {
+      const res = await fetch('/api/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ role, name })
+      });
+      if (!res.ok) throw new Error('Failed');
+      const data = await res.json();
+      localStorage.setItem('token', data.token);
+      onLogin(data.role, data.name);
+    } catch {
+      alert('Ошибка авторизации');
+    }
   }
 
   return (

--- a/src/pages/ClubDashboard.tsx
+++ b/src/pages/ClubDashboard.tsx
@@ -1,21 +1,30 @@
-const mockClub = {
-  name: 'Центр развития "Юный гений"',
-  city: 'Астана',
-  phone: '+7 777 123 4567',
-  email: 'info@jun-gen.kz',
-  address: 'ул. Абая, 10',
-  directions: ['Робототехника', 'Шахматы', 'Арт-студия'],
-  studentsCount: 32,
-  teachers: ['Иванов А.А.', 'Серикова М.М.'],
-  photoUrl: 'https://images.unsplash.com/photo-1517841905240-472988babdf9?w=400&q=80'
+import { useEffect, useState } from 'react';
+
+type Dashboard = {
+  club: {
+    name: string;
+    city: string;
+    phone: string;
+    email: string;
+    address: string;
+    directions: string[];
+    studentsCount: number;
+    teachers: string[];
+    photoUrl: string;
+  };
+  schedule: { id: number; name: string; days: string; time: string }[];
 };
 
-const mockSchedule = [
-  { id: 1, name: 'Робототехника', days: 'Пн, Ср, Пт', time: '15:00–16:30' },
-  { id: 2, name: 'Шахматы', days: 'Вт, Чт', time: '16:00–17:00' }
-];
-
 export default function ClubDashboard() {
+  const [data, setData] = useState<Dashboard | null>(null);
+
+  useEffect(() => {
+    fetch('/api/club/dashboard')
+      .then(r => r.json())
+      .then(setData)
+      .catch(() => setData(null));
+  }, []);
+
   return (
     <div style={{
       maxWidth: 860,
@@ -28,8 +37,8 @@ export default function ClubDashboard() {
     }}>
       <div style={{ display: 'flex', alignItems: 'center', gap: 28, marginBottom: 18 }}>
         <img
-          src={mockClub.photoUrl}
-          alt={mockClub.name}
+          src={data?.club.photoUrl}
+          alt={data?.club.name}
           style={{
             width: 94,
             height: 94,
@@ -46,30 +55,30 @@ export default function ClubDashboard() {
             fontWeight: 900,
             color: '#4AA7F5',
             marginBottom: 5
-          }}>{mockClub.name}</div>
+          }}>{data?.club.name}</div>
           <div style={{
             color: '#A7E04B',
             fontWeight: 800,
             fontSize: 16,
             marginBottom: 1
-          }}>{mockClub.city}, {mockClub.address}</div>
+          }}>{data?.club.city}, {data?.club.address}</div>
           <div style={{
             color: '#333',
             fontWeight: 700,
             fontSize: 15,
             marginBottom: 3
-          }}>Тел: <span style={{ color: '#4AA7F5' }}>{mockClub.phone}</span></div>
+          }}>Тел: <span style={{ color: '#4AA7F5' }}>{data?.club.phone}</span></div>
           <div style={{
             color: '#888',
             fontSize: 15,
             marginBottom: 3
-          }}>{mockClub.email}</div>
+          }}>{data?.club.email}</div>
           <div style={{
             color: '#A7E04B',
             fontWeight: 800,
             fontSize: 16
           }}>
-            Направления: <span style={{ color: '#222' }}>{mockClub.directions.join(', ')}</span>
+            Направления: <span style={{ color: '#222' }}>{data?.club.directions.join(', ')}</span>
           </div>
           <div style={{
             color: '#4AA7F5',
@@ -77,7 +86,7 @@ export default function ClubDashboard() {
             marginTop: 7,
             fontSize: 16
           }}>
-            Учеников: {mockClub.studentsCount}
+            Учеников: {data?.club.studentsCount}
           </div>
         </div>
       </div>
@@ -97,7 +106,7 @@ export default function ClubDashboard() {
           marginBottom: 14
         }}>👩‍🏫 Педагоги</div>
         <ul style={{ paddingLeft: 18, fontSize: 16, fontWeight: 700, color: '#34480A' }}>
-          {mockClub.teachers.map(t => (
+          {data?.club.teachers.map(t => (
             <li key={t} style={{ marginBottom: 6 }}>{t}</li>
           ))}
         </ul>
@@ -132,7 +141,7 @@ export default function ClubDashboard() {
             </tr>
           </thead>
           <tbody>
-            {mockSchedule.map(row => (
+            {data?.schedule?.map(row => (
               <tr key={row.id} style={{ background: row.id % 2 === 0 ? '#F7FCFF' : '#fff' }}>
                 <td style={{ padding: 9 }}>{row.name}</td>
                 <td style={{ padding: 9 }}>{row.days}</td>

--- a/src/pages/ClubsCatalog.tsx
+++ b/src/pages/ClubsCatalog.tsx
@@ -1,40 +1,30 @@
-const mockClubs = [
-  {
-    id: 1,
-    name: 'Робототехника Junior',
-    city: 'Астана',
-    address: 'ул. Абая, 11',
-    direction: 'Техническое',
-    age: '7-11',
-    price: '20 000 ₸',
-    image: 'https://images.unsplash.com/photo-1519125323398-675f0ddb6308?auto=format&fit=facearea&w=400&q=80',
-    desc: 'Роботы, 3D-принтеры, соревнования и творчество для детей.',
-  },
-  {
-    id: 2,
-    name: 'Шахматная академия',
-    city: 'Астана',
-    address: 'пр. Мангилик Ел, 12',
-    direction: 'Логика',
-    age: '6-14',
-    price: '15 000 ₸',
-    image: 'https://images.unsplash.com/photo-1503676382389-4809596d5290?auto=format&fit=facearea&w=400&q=80',
-    desc: 'Обучение шахматам в группах и индивидуально. Турниры каждую неделю!',
-  },
-  {
-    id: 3,
-    name: 'Арт-студия "Краски"',
-    city: 'Астана',
-    address: 'ул. Сарыарка, 7',
-    direction: 'Творчество',
-    age: '5-12',
-    price: '18 000 ₸',
-    image: 'https://images.unsplash.com/photo-1517841905240-472988babdf9?w=400&q=80',
-    desc: 'Живопись, лепка, творчество и развитие эстетического вкуса.',
-  }
-];
+import { useEffect, useState } from 'react';
+import { ClubCard } from '../components/ClubCard';
+
+type Club = {
+  id: number;
+  name: string;
+  city: string;
+  address: string;
+  direction: string;
+  age: string;
+  price: string;
+  image: string;
+  desc: string;
+};
 
 export default function ClubsCatalog() {
+  const [clubs, setClubs] = useState<Club[]>([]);
+  const [city, setCity] = useState('');
+  const [direction, setDirection] = useState('');
+  const [age, setAge] = useState('');
+
+  useEffect(() => {
+    fetch('/api/clubs')
+      .then(r => r.json())
+      .then(data => setClubs(data))
+      .catch(() => setClubs([]));
+  }, []);
   return (
     <div style={{
       maxWidth: 1100,
@@ -53,7 +43,6 @@ export default function ClubsCatalog() {
         Каталог кружков и секций
       </h2>
 
-      {/* Блок фильтрации-заглушки */}
       <div style={{
         display: 'flex',
         gap: 20,
@@ -61,9 +50,24 @@ export default function ClubsCatalog() {
         flexWrap: 'wrap',
         justifyContent: 'center'
       }}>
-        <select style={filterStyle}><option>Город: Астана</option></select>
-        <select style={filterStyle}><option>Направление: Все</option></select>
-        <select style={filterStyle}><option>Возраст: Все</option></select>
+        <input
+          placeholder="Город"
+          value={city}
+          onChange={e => setCity(e.target.value)}
+          style={filterStyle}
+        />
+        <input
+          placeholder="Направление"
+          value={direction}
+          onChange={e => setDirection(e.target.value)}
+          style={filterStyle}
+        />
+        <input
+          placeholder="Возраст"
+          value={age}
+          onChange={e => setAge(e.target.value)}
+          style={filterStyle}
+        />
       </div>
 
       <div style={{
@@ -71,93 +75,21 @@ export default function ClubsCatalog() {
         gap: 32,
         gridTemplateColumns: 'repeat(auto-fit,minmax(320px,1fr))'
       }}>
-        {mockClubs.map(club => (
-          <div key={club.id} style={{
-            background: '#fff',
-            borderRadius: 26,
-            boxShadow: '0 4px 24px #0001',
-            padding: '0 0 24px 0',
-            overflow: 'hidden',
-            display: 'flex',
-            flexDirection: 'column'
-          }}>
-            <img
-              src={club.image}
-              alt={club.name}
-              style={{
-                width: '100%',
-                height: 180,
-                objectFit: 'cover',
-                borderTopLeftRadius: 26,
-                borderTopRightRadius: 26
-              }}
-            />
-            <div style={{ padding: '22px 24px 0 24px', flex: 1 }}>
-              <div style={{
-                fontSize: 22,
-                fontWeight: 900,
-                color: '#4AA7F5',
-                marginBottom: 4,
-                lineHeight: 1.1
-              }}>{club.name}</div>
-              <div style={{
-                color: '#A7E04B',
-                fontWeight: 800,
-                fontSize: 15,
-                marginBottom: 4
-              }}>{club.direction}</div>
-              <div style={{
-                fontSize: 15,
-                color: '#888',
-                marginBottom: 8
-              }}>
-                {club.city}, {club.address}
-              </div>
-              <div style={{
-                fontSize: 16,
-                color: '#333',
-                fontWeight: 700,
-                marginBottom: 6
-              }}>
-                Возраст: <span style={{ color: '#4AA7F5' }}>{club.age}</span>
-              </div>
-              <div style={{
-                fontSize: 16,
-                color: '#E3A00C',
-                fontWeight: 800,
-                marginBottom: 11
-              }}>
-                {club.price}
-              </div>
-              <div style={{
-                fontSize: 15,
-                color: '#444',
-                marginBottom: 11
-              }}>{club.desc}</div>
-            </div>
-            <div style={{
-              display: 'flex',
-              justifyContent: 'center'
-            }}>
-              <button
-                style={{
-                  background: 'linear-gradient(90deg,#A7E04B 60%,#4AA7F5 100%)',
-                  color: '#222',
-                  fontWeight: 900,
-                  fontSize: 17,
-                  border: 'none',
-                  borderRadius: 14,
-                  padding: '13px 38px',
-                  cursor: 'pointer',
-                  marginTop: 10,
-                  marginBottom: 5,
-                  boxShadow: '0 2px 8px #4aa7f520'
-                }}
-              >
-                Записаться
-              </button>
-            </div>
-          </div>
+        {clubs
+          .filter(c => (!city || c.city.toLowerCase().includes(city.toLowerCase())) &&
+            (!direction || c.direction.toLowerCase().includes(direction.toLowerCase())) &&
+            (!age || c.age.includes(age)))
+          .map(club => (
+            <ClubCard key={club.id} club={{
+              id: club.id,
+              title: club.name,
+              city: club.city,
+              age: club.age,
+              direction: club.direction,
+              price: club.price,
+              image: club.image,
+              rating: 5
+            }} />
         ))}
       </div>
     </div>

--- a/src/pages/ParentDashboard.tsx
+++ b/src/pages/ParentDashboard.tsx
@@ -1,21 +1,21 @@
-const mockChild = {
-  name: 'Айжан',
-  age: 9,
-  interests: ['Робототехника', 'Рисование', 'Футбол'],
-  photoUrl: 'https://randomuser.me/api/portraits/med/women/43.jpg'
+import { useEffect, useState } from 'react';
+
+type Dashboard = {
+  child: { name: string; age: number; interests: string[]; photoUrl: string };
+  records: { id: number; club: string; date: string; status: string }[];
+  events: { id: number; date: string; event: string }[];
 };
 
-const mockRecords = [
-  { id: 1, club: 'Робототехника Junior', date: '2024-09-01', status: 'Записан' },
-  { id: 2, club: 'Футбольная секция "Звезда"', date: '2024-09-02', status: 'Посещено' }
-];
-
-const mockEvents = [
-  { id: 1, date: '2024-09-03', event: 'Открытый урок по рисованию' },
-  { id: 2, date: '2024-09-05', event: 'Запись в "Робототехника Junior"' }
-];
-
 export default function ParentDashboard() {
+  const [data, setData] = useState<Dashboard | null>(null);
+
+  useEffect(() => {
+    fetch('/api/parent/dashboard')
+      .then(r => r.json())
+      .then(setData)
+      .catch(() => setData(null));
+  }, []);
+
   return (
     <div style={{
       maxWidth: 740,
@@ -28,8 +28,8 @@ export default function ParentDashboard() {
     }}>
       <div style={{ display: 'flex', alignItems: 'center', gap: 24, marginBottom: 22 }}>
         <img
-          src={mockChild.photoUrl}
-          alt={mockChild.name}
+          src={data?.child.photoUrl}
+          alt={data?.child.name}
           style={{
             width: 88,
             height: 88,
@@ -46,19 +46,19 @@ export default function ParentDashboard() {
             fontWeight: 900,
             color: '#4AA7F5',
             marginBottom: 4
-          }}>{mockChild.name}</div>
+          }}>{data?.child.name}</div>
           <div style={{
             color: '#555',
             fontWeight: 700,
             fontSize: 18
-          }}>{mockChild.age} лет</div>
+          }}>{data?.child.age} лет</div>
           <div style={{
             color: '#A7E04B',
             fontWeight: 800,
             fontSize: 16,
             marginTop: 2
           }}>
-            Интересы: <span style={{ color: '#222' }}>{mockChild.interests.join(', ')}</span>
+            Интересы: <span style={{ color: '#222' }}>{data?.child.interests.join(', ')}</span>
           </div>
         </div>
       </div>
@@ -85,7 +85,7 @@ export default function ParentDashboard() {
             letterSpacing: 1
           }}>История записей</div>
           <ul style={{ paddingLeft: 14, fontSize: 15, fontWeight: 600, color: '#34480A' }}>
-            {mockRecords.map(rec => (
+            {data?.records?.map(rec => (
               <li key={rec.id} style={{ marginBottom: 7 }}>
                 <span style={{ color: '#4AA7F5', fontWeight: 800 }}>{rec.club}</span><br />
                 <span style={{ color: '#888' }}>{rec.date}</span>{' '}
@@ -114,7 +114,7 @@ export default function ParentDashboard() {
             letterSpacing: 1
           }}>Ближайшие события</div>
           <ul style={{ paddingLeft: 14, fontSize: 15, fontWeight: 600, color: '#B88D0B' }}>
-            {mockEvents.map(ev => (
+            {data?.events?.map(ev => (
               <li key={ev.id} style={{ marginBottom: 7 }}>
                 <span style={{ color: '#4AA7F5', fontWeight: 800 }}>{ev.date}</span>{' '}
                 <span>{ev.event}</span>


### PR DESCRIPTION
## Summary
- introduce simple Node server with in-memory data
- fetch data from API in catalog and dashboards
- connect login page to API and store token
- use `ClubCard` component in catalog
- add `npm run server` script

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6860491945ac8329b69f0cf39a4ec010